### PR TITLE
test initiate_liquidity_withdraw

### DIFF
--- a/contracts/.snfoundry_cache/.prev_tests_failed
+++ b/contracts/.snfoundry_cache/.prev_tests_failed
@@ -1,1 +1,0 @@
-zkramp::contracts::ramps::revolut::revolut_test::test_initiate_liquidity_withdraw_without_enough_liquidity

--- a/contracts/.snfoundry_cache/.prev_tests_failed
+++ b/contracts/.snfoundry_cache/.prev_tests_failed
@@ -1,0 +1,1 @@
+zkramp::contracts::ramps::revolut::revolut_test::test_initiate_liquidity_withdraw_without_enough_liquidity

--- a/contracts/src/components/registry/interface.cairo
+++ b/contracts/src/components/registry/interface.cairo
@@ -3,7 +3,9 @@ use zkramp::utils::hash::HashSerializable;
 
 #[derive(Drop, Copy, Serde, Debug, PartialEq, starknet::Store)]
 pub enum OffchainId {
-    Revolut: felt252
+    #[default]
+    None,
+    Revolut: felt252,
 }
 
 #[starknet::interface]

--- a/contracts/src/contracts/ramps/revolut/revolut.cairo
+++ b/contracts/src/contracts/ramps/revolut/revolut.cairo
@@ -35,8 +35,8 @@ pub mod RevolutRamp {
     // Constants
     //
 
-    const LOCK_DURATION_STEP: u64 = 900; // 15min
-    const MINIMUM_LOCK_DURATION: u64 = 3600; // 1h
+    pub const LOCK_DURATION_STEP: u64 = 900; // 15min
+    pub const MINIMUM_LOCK_DURATION: u64 = 3600; // 1h
 
     //
     // Storage

--- a/contracts/src/contracts/ramps/revolut/revolut_test.cairo
+++ b/contracts/src/contracts/ramps/revolut/revolut_test.cairo
@@ -373,40 +373,177 @@ fn test_retrieve_liquidity_with_expired_requests() {
 // initiate_liquidity_withdraw & withdraw_liquidity
 //
 
-// #[test]
-// #[should_panic(expected: 'Caller is the owner')]
+#[test]
+#[should_panic(expected: 'Caller is the owner')]
 fn test_initiate_liquidity_withdraw_from_owner() {
-    panic!("Not implemented yet");
+    let (revolut_ramp, erc20) = setup();
+    let liquidity_owner = constants::OTHER();
+    let offchain_id = constants::REVOLUT_ID();
+    let amount = 42;
+    let liquidity_key = LiquidityKey { owner: liquidity_owner, offchain_id };
+
+    // fund the account
+    fund_and_approve(token: erc20, recipient: liquidity_owner, spender: revolut_ramp.contract_address, :amount);
+
+    // register offchain ID
+    start_cheat_caller_address(revolut_ramp.contract_address, liquidity_owner);
+    revolut_ramp.register(:offchain_id);
+
+    // add liquidity
+    revolut_ramp.add_liquidity(amount: amount, :offchain_id);
+
+    // initiate liquidity withdraw
+    revolut_ramp.initiate_liquidity_withdrawal(:liquidity_key, :amount, :offchain_id);
 }
 
-// #[test]
-// #[should_panic(expected: 'Amount cannot be null')]
+#[test]
+#[should_panic(expected: 'Amount cannot be null')]
 fn test_initiate_liquidity_withdraw_zero_amount() {
-    panic!("Not implemented yet");
+    let (revolut_ramp, erc20) = setup();
+    let liquidity_owner = constants::OTHER();
+    let liquidity_withdrawer = constants::CALLER();
+    let offchain_id = constants::REVOLUT_ID();
+    let offchain_id_withdrawer = constants::OTHER_REVOLUT_ID();
+    let amount = 42;
+    let liquidity_key = LiquidityKey { owner: liquidity_owner, offchain_id };
+
+    // fund the account
+    fund_and_approve(token: erc20, recipient: liquidity_owner, spender: revolut_ramp.contract_address, :amount);
+
+    // register offchain ID owner
+    start_cheat_caller_address(revolut_ramp.contract_address, liquidity_owner);
+    revolut_ramp.register(:offchain_id);
+
+    // add liquidity
+    revolut_ramp.add_liquidity(amount: amount, :offchain_id);
+
+    // register offchain ID withdrawer
+    start_cheat_caller_address(revolut_ramp.contract_address, liquidity_withdrawer);
+    revolut_ramp.register(offchain_id: offchain_id_withdrawer);
+
+    // initiate liquidity withdraw
+    revolut_ramp.initiate_liquidity_withdrawal(:liquidity_key, amount: 0, offchain_id: offchain_id_withdrawer);
 }
 
-// #[test]
-// #[should_panic(expected: 'Liquidity is not available')]
+#[test]
+#[should_panic(expected: 'Liquidity is not available')]
 fn test_initiate_liquidity_withdraw_locked() {
-    panic!("Not implemented yet");
+    let (revolut_ramp, erc20) = setup();
+    let liquidity_owner = constants::OTHER();
+    let liquidity_withdrawer = constants::CALLER();
+    let offchain_id = constants::REVOLUT_ID();
+    let offchain_id_withdrawer = constants::OTHER_REVOLUT_ID();
+    let amount = 42;
+    let liquidity_key = LiquidityKey { owner: liquidity_owner, offchain_id };
+
+    // fund the account
+    fund_and_approve(token: erc20, recipient: liquidity_owner, spender: revolut_ramp.contract_address, :amount);
+
+    // register offchain ID owner
+    start_cheat_caller_address(revolut_ramp.contract_address, liquidity_owner);
+    revolut_ramp.register(:offchain_id);
+
+    // add liquidity
+    revolut_ramp.add_liquidity(amount: amount, :offchain_id);
+
+    // locks liquidity
+    revolut_ramp.initiate_liquidity_retrieval(:liquidity_key);
+
+    // register offchain ID withdrawer
+    start_cheat_caller_address(revolut_ramp.contract_address, liquidity_withdrawer);
+    revolut_ramp.register(offchain_id: offchain_id_withdrawer);
+
+    // initiate liquidity withdraw
+    revolut_ramp.initiate_liquidity_withdrawal(:liquidity_key, :amount, offchain_id: offchain_id_withdrawer);
 }
 
-// #[test]
-// #[should_panic(expected: 'Caller is not registered')]
+#[test]
+#[should_panic(expected: 'Caller is not registered')]
 fn test_initiate_liquidity_withdraw_with_unregistered_offchain_id() {
-    panic!("Not implemented yet");
+    let (revolut_ramp, erc20) = setup();
+    let liquidity_owner = constants::OTHER();
+    let liquidity_withdrawer = constants::CALLER();
+    let offchain_id = constants::REVOLUT_ID();
+    let offchain_id_withdrawer = constants::OTHER_REVOLUT_ID();
+    let amount = 42;
+    let liquidity_key = LiquidityKey { owner: liquidity_owner, offchain_id };
+
+    // fund the account
+    fund_and_approve(token: erc20, recipient: liquidity_owner, spender: revolut_ramp.contract_address, :amount);
+
+    // register offchain ID owner
+    start_cheat_caller_address(revolut_ramp.contract_address, liquidity_owner);
+    revolut_ramp.register(:offchain_id);
+
+    // add liquidity
+    revolut_ramp.add_liquidity(amount: amount, :offchain_id);
+
+    // initiate liquidity withdraw
+    start_cheat_caller_address(revolut_ramp.contract_address, liquidity_withdrawer);
+    revolut_ramp.initiate_liquidity_withdrawal(:liquidity_key, :amount, offchain_id: offchain_id_withdrawer);
 }
 
-// #[test]
-// #[should_panic(expected: 'Not enough liquidity')]
+#[test]
+#[should_panic(expected: 'Not enough liquidity')]
 fn test_initiate_liquidity_withdraw_without_enough_liquidity() {
-    panic!("Not implemented yet");
+    let (revolut_ramp, erc20) = setup();
+    let liquidity_owner = constants::OTHER();
+    let liquidity_withdrawer = constants::CALLER();
+    let offchain_id = constants::REVOLUT_ID();
+    let offchain_id_withdrawer = constants::OTHER_REVOLUT_ID();
+    let amount1 = 42;
+    let amount2 = 75;
+    let liquidity_key = LiquidityKey { owner: liquidity_owner, offchain_id };
+
+    // fund the account
+    fund_and_approve(token: erc20, recipient: liquidity_owner, spender: revolut_ramp.contract_address, amount: amount1);
+
+    // register offchain ID owner
+    start_cheat_caller_address(revolut_ramp.contract_address, liquidity_owner);
+    revolut_ramp.register(:offchain_id);
+
+    // add liquidity
+    revolut_ramp.add_liquidity(amount: amount1, :offchain_id);
+
+    // register offchain ID withdrawer
+    start_cheat_caller_address(revolut_ramp.contract_address, liquidity_withdrawer);
+    revolut_ramp.register(offchain_id: offchain_id_withdrawer);
+
+    // initiate liquidity withdraw
+    revolut_ramp.initiate_liquidity_withdrawal(:liquidity_key, amount: amount2, offchain_id: offchain_id_withdrawer);
 }
 
 // #[test]
 // #[should_panic(expected: 'Not enough liquidity')]
 fn test_initiate_liquidity_withdraw_without_enough_available_liquidity() {
-    panic!("Not implemented yet");
+    let (revolut_ramp, erc20) = setup();
+    let liquidity_owner = constants::OTHER();
+    let liquidity_withdrawer = constants::CALLER();
+    let offchain_id = constants::REVOLUT_ID();
+    let offchain_id_withdrawer = constants::OTHER_REVOLUT_ID();
+    let amount1 = 42;
+    let amount2 = 75;
+    let liquidity_key = LiquidityKey { owner: liquidity_owner, offchain_id };
+
+    // fund the account
+    fund_and_approve(token: erc20, recipient: liquidity_owner, spender: revolut_ramp.contract_address, amount: amount2);
+
+    // register offchain ID owner
+    start_cheat_caller_address(revolut_ramp.contract_address, liquidity_owner);
+    revolut_ramp.register(:offchain_id);
+
+    // add liquidity
+    revolut_ramp.add_liquidity(amount: amount2, :offchain_id);
+
+    // register offchain ID withdrawer
+    start_cheat_caller_address(revolut_ramp.contract_address, liquidity_withdrawer);
+    revolut_ramp.register(offchain_id: offchain_id_withdrawer);
+
+    // initiate liquidity withdraw
+    revolut_ramp.initiate_liquidity_withdrawal(:liquidity_key, amount: amount1, offchain_id: offchain_id_withdrawer);
+
+    // initiate liquidity withdraw
+    revolut_ramp.initiate_liquidity_withdrawal(:liquidity_key, amount: amount1, offchain_id: offchain_id_withdrawer);
 }
 
 // #[test]

--- a/contracts/src/tests/constants.cairo
+++ b/contracts/src/tests/constants.cairo
@@ -39,6 +39,10 @@ pub fn OTHER() -> ContractAddress {
     contract_address_const::<'other'>()
 }
 
+pub fn OTHER2() -> ContractAddress {
+    contract_address_const::<'other2'>()
+}
+
 pub const SUPPLY: u256 = 1_000_000_000_000_000_000; // 1 ETH
 
 

--- a/contracts/src/tests/constants.cairo
+++ b/contracts/src/tests/constants.cairo
@@ -3,8 +3,14 @@ use zkramp::components::registry::interface::OffchainId;
 
 const REVTAG: felt252 = 'just a random revtag hash';
 
+const REVTAG2: felt252 = 'just another random revtag hash';
+
 pub fn REVOLUT_ID() -> OffchainId {
     OffchainId::Revolut(REVTAG)
+}
+
+pub fn OTHER_REVOLUT_ID() -> OffchainId {
+    OffchainId::Revolut(REVTAG2)
 }
 
 pub fn CALLER() -> ContractAddress {

--- a/contracts/src/tests/constants.cairo
+++ b/contracts/src/tests/constants.cairo
@@ -3,14 +3,20 @@ use zkramp::components::registry::interface::OffchainId;
 
 const REVTAG: felt252 = 'just a random revtag hash';
 
-const REVTAG2: felt252 = 'just another random revtag hash';
+const REVTAG2: felt252 = 'just a 2nd random revtag hash';
+
+const REVTAG3: felt252 = 'just a 3rd random revtag hash';
 
 pub fn REVOLUT_ID() -> OffchainId {
     OffchainId::Revolut(REVTAG)
 }
 
-pub fn OTHER_REVOLUT_ID() -> OffchainId {
+pub fn REVOLUT_ID2() -> OffchainId {
     OffchainId::Revolut(REVTAG2)
+}
+
+pub fn REVOLUT_ID3() -> OffchainId {
+    OffchainId::Revolut(REVTAG3)
 }
 
 pub fn CALLER() -> ContractAddress {


### PR DESCRIPTION
Resolves: #86 

bug : 

The test : `test_initiate_liquidity_withdraw_without_enough_liquidity`

raises : 
```
Failure data:
Incorrect panic data
Actual:    [0x556e6b6e6f776e20656e756d20696e64696361746f723a, 0x0] (Unknown enum indicator:, )
Expected:  [0x4e6f7420656e6f756768206c6971756964697479] (Not enough liquidity)
```

Portion of the code that panic : https://github.com/keep-starknet-strange/zkramp/blob/main/contracts/src/contracts/ramps/revolut/revolut.cairo#L268-L271