### PR TITLE
test(revolut_test): Added _get_next_timestamp_key tests

### DIFF
--- a/contracts/src/contracts/ramps/revolut/revolut.cairo
+++ b/contracts/src/contracts/ramps/revolut/revolut.cairo
@@ -347,7 +347,7 @@ pub mod RevolutRamp {
     //
 
     #[generate_trait]
-    impl InternalImpl of InternalTrait {
+    pub impl InternalImpl of InternalTrait {
         fn _get_available_liquidity(self: @ContractState, liquidity_key: LiquidityKey) -> u256 {
             let mut amount = self.liquidity.read(liquidity_key);
             let current_timestamp = get_block_timestamp();
@@ -362,8 +362,14 @@ pub mod RevolutRamp {
         }
 
         fn _get_next_timestamp_key(self: @ContractState, after: u64) -> u64 {
-            // minus 1 in order to return `after` if it's already a valid key timestamp.
-            after - 1 + LOCK_DURATION_STEP - ((after - 1) % LOCK_DURATION_STEP)
+            if after.is_zero() {
+                0
+            } else {
+                // minus 1 in order to return `after` if it's already a valid key timestamp.
+                let increment_step = (after - 1) / LOCK_DURATION_STEP + 1;
+                // returns a multiple of LOCK_DURATION_STEP
+                LOCK_DURATION_STEP * increment_step
+            }
         }
     }
 }

--- a/contracts/src/contracts/ramps/revolut/revolut_test.cairo
+++ b/contracts/src/contracts/ramps/revolut/revolut_test.cairo
@@ -1172,8 +1172,10 @@ fn test_withdraw_liquidity_twice() {
 fn test__get_next_timestamp_key_basic() {
     // setup
     let state = RevolutRamp::contract_state_for_testing();
+
     // test a value between 0 and LOCK_DURATION_STEP
-    let after = 10;
+    let after = 42;
+
     // should be rounded to the next threshold
     assert_eq!(state._get_next_timestamp_key(:after), LOCK_DURATION_STEP);
 }
@@ -1182,18 +1184,22 @@ fn test__get_next_timestamp_key_basic() {
 fn test__get_next_timestamp_key_for_timestamp_key() {
     // setup
     let state = RevolutRamp::contract_state_for_testing();
+
     // test a multiple of LOCK_DURATION_STEP
-    let after = MINIMUM_LOCK_DURATION;
+    let after = LOCK_DURATION_STEP * 42;
+
     // should return the same value
-    assert_eq!(state._get_next_timestamp_key(:after), MINIMUM_LOCK_DURATION);
+    assert_eq!(state._get_next_timestamp_key(:after), after);
 }
 
 #[test]
 fn test__get_next_timestamp_key_from_zero() {
     // setup
     let state = RevolutRamp::contract_state_for_testing();
+
     // test with 0
     let after = 0;
+
     // should return the same value
     assert_eq!(state._get_next_timestamp_key(:after), 0);
 }

--- a/contracts/src/contracts/ramps/revolut/revolut_test.cairo
+++ b/contracts/src/contracts/ramps/revolut/revolut_test.cairo
@@ -9,8 +9,9 @@ use snforge_std::{
 use zkramp::contracts::ramps::revolut::interface::{ZKRampABIDispatcher, ZKRampABIDispatcherTrait, LiquidityKey};
 use zkramp::contracts::ramps::revolut::revolut::RevolutRamp::{
     Event, LiquidityAdded, LiquidityRetrieved, LiquidityLocked, LiquidityShareRequested, LiquidityShareWithdrawn,
-    MINIMUM_LOCK_DURATION
+    InternalImpl as RevolutRampInternalImpl, MINIMUM_LOCK_DURATION, LOCK_DURATION_STEP
 };
+use zkramp::contracts::ramps::revolut::revolut::RevolutRamp;
 use zkramp::tests::constants;
 use zkramp::tests::utils;
 
@@ -1167,19 +1168,34 @@ fn test_withdraw_liquidity_twice() {
 // _get_next_timestamp_key
 //
 
-// #[test]
+#[test]
 fn test__get_next_timestamp_key_basic() {
-    panic!("Not implemented yet");
+    // setup
+    let state = RevolutRamp::contract_state_for_testing();
+    // test a value between 0 and LOCK_DURATION_STEP
+    let after = 10;
+    // should be rounded to the next threshold
+    assert_eq!(state._get_next_timestamp_key(:after), LOCK_DURATION_STEP);
 }
 
-// #[test]
+#[test]
 fn test__get_next_timestamp_key_for_timestamp_key() {
-    panic!("Not implemented yet");
+    // setup
+    let state = RevolutRamp::contract_state_for_testing();
+    // test a multiple of LOCK_DURATION_STEP
+    let after = MINIMUM_LOCK_DURATION;
+    // should return the same value
+    assert_eq!(state._get_next_timestamp_key(:after), MINIMUM_LOCK_DURATION);
 }
 
-// #[test]
+#[test]
 fn test__get_next_timestamp_key_from_zero() {
-    panic!("Not implemented yet");
+    // setup
+    let state = RevolutRamp::contract_state_for_testing();
+    // test with 0
+    let after = 0;
+    // should return the same value
+    assert_eq!(state._get_next_timestamp_key(:after), 0);
 }
 
 // #[test]


### PR DESCRIPTION
 
* added tests

* changed _get_next_timestamp_key to return 0 on 0 input

* _get_next_timestamp_key is more readable

 [CONTRACTS] implement _get_next_timestamp_key tests #88